### PR TITLE
Refactor MultiSelectTreeViewControl context menu binding

### DIFF
--- a/src/Velopack.UI/Controls/MultiSelectTreeViewControl.xaml
+++ b/src/Velopack.UI/Controls/MultiSelectTreeViewControl.xaml
@@ -3,10 +3,10 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:dd="clr-namespace:GongSolutions.Wpf.DragDrop;assembly=GongSolutions.Wpf.DragDrop"
     xmlns:local="clr-namespace:Velopack.UI.MultiSelectTreeView.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="https://github.com/reactivemarbles/CrissCross.ui"
-    xmlns:dd="clr-namespace:GongSolutions.Wpf.DragDrop;assembly=GongSolutions.Wpf.DragDrop"
     x:Name="Root"
     d:DesignHeight="300"
     d:DesignWidth="400"
@@ -14,7 +14,7 @@
     <UserControl.Resources>
         <local:ItemInListConverter x:Key="ItemInListConverter" />
 
-        <!-- Default item template with icon and filename, themed brushes -->
+        <!--  Default item template with icon and filename, inherit theme foreground  -->
         <HierarchicalDataTemplate x:Key="DefaultItemTemplate" ItemsSource="{Binding Children}">
             <ui:Border
                 x:Name="bd"
@@ -25,11 +25,11 @@
                     <Style TargetType="ui:Border">
                         <Setter Property="Background" Value="Transparent" />
                         <Setter Property="BorderBrush" Value="Transparent" />
-                        <Setter Property="TextElement.Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding IsSelected}" Value="True">
                                 <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
                                 <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                                <!--  Ensure readable text in both light/dark when selected  -->
                                 <Setter Property="TextElement.Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
                             </DataTrigger>
                         </Style.Triggers>
@@ -48,7 +48,7 @@
     </UserControl.Resources>
 
     <ui:Grid>
-        <!-- Overlay hint when no items -->
+        <!--  Overlay hint when no items  -->
         <ui:Grid>
             <ui:Grid.Style>
                 <Style TargetType="ui:Grid">
@@ -67,8 +67,7 @@
                 FontSize="38"
                 FontWeight="Light"
                 Opacity=".3"
-                Text="Drag files here"
-                Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                Text="Drag files here" />
             <Path
                 MaxWidth="192"
                 MaxHeight="192"
@@ -83,33 +82,36 @@
 
         <TreeView
             x:Name="PART_Tree"
+            dd:DragDrop.DropHandler="{Binding ElementName=Root, Path=DataContext}"
+            dd:DragDrop.IsDragSource="True"
+            dd:DragDrop.IsDropTarget="True"
+            dd:DragDrop.UseDefaultDragAdorner="True"
+            AllowDrop="True"
             Background="{x:Null}"
             BorderThickness="0"
             Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
             ItemTemplate="{Binding ElementName=Root, Path=ItemTemplate, TargetNullValue={StaticResource DefaultItemTemplate}}"
             ItemsSource="{Binding ElementName=Root, Path=ItemsSource}"
-            AllowDrop="True"
-            dd:DragDrop.IsDragSource="True"
-            dd:DragDrop.IsDropTarget="True"
-            dd:DragDrop.UseDefaultDragAdorner="True"
-            dd:DragDrop.DropHandler="{Binding ElementName=Root, Path=DataContext}"
             PreviewKeyDown="OnTreeViewPreviewKeyDown"
             PreviewMouseLeftButtonDown="OnTreeViewPreviewMouseLeftButtonDown"
             PreviewMouseRightButtonDown="OnTreeViewPreviewMouseRightButtonDown">
             <TreeView.Resources>
-                <!-- Item container style for expansion, selection, per-item context menu and themed appearance -->
+                <!--  Item container style for expansion, selection, per-item context menu  -->
                 <Style TargetType="TreeViewItem">
                     <Setter Property="Padding" Value="2" />
                     <Setter Property="Margin" Value="0" />
                     <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
                     <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
                     <Setter Property="FontWeight" Value="Normal" />
+                    <!--  Flow VM to item via Tag  -->
+                    <Setter Property="Tag" Value="{Binding DataContext, RelativeSource={RelativeSource AncestorType=UserControl}}" />
                     <Setter Property="ContextMenu">
                         <Setter.Value>
-                            <ContextMenu DataContext="{Binding ElementName=Root, Path=DataContext}">
-                                <MenuItem Command="{Binding RefreshPackageVersionCommand}" CommandParameter="{Binding}" Header="Refresh Version" />
-                                <MenuItem Command="{Binding AddDirectoryCommand}" CommandParameter="{Binding}" Header="Add Directory" />
-                                <MenuItem Command="{Binding RemoveItemCommand}" CommandParameter="{Binding}" Header="Remove Selected Items" />
+                            <!-- Bind commands to VM; no parameters (ReactiveCommand<Unit,Unit>) -->
+                            <ContextMenu DataContext="{Binding PlacementTarget.Tag, RelativeSource={RelativeSource Self}}">
+                                <MenuItem Command="{Binding RefreshPackageVersionCommand}" Header="Refresh Version" />
+                                <MenuItem Command="{Binding AddDirectoryCommand}" Header="Add Directory" />
+                                <MenuItem Command="{Binding RemoveItemCommand}" Header="Remove Selected Items" />
                                 <MenuItem Command="{Binding RemoveAllItemsCommand}" Header="Remove All Items" />
                             </ContextMenu>
                         </Setter.Value>
@@ -122,19 +124,11 @@
                 </Style>
             </TreeView.Resources>
             <TreeView.ContextMenu>
+                <!--  Tree-level menu: VM from PlacementTarget.DataContext; no parameters  -->
                 <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                    <MenuItem
-                        Command="{Binding RefreshPackageVersionCommand}"
-                        CommandParameter="{Binding ElementName=Root, Path=SelectedItems}"
-                        Header="Refresh Version" />
-                    <MenuItem
-                        Command="{Binding AddDirectoryCommand}"
-                        CommandParameter="{Binding ElementName=Root, Path=SelectedItems}"
-                        Header="Add Directory" />
-                    <MenuItem
-                        Command="{Binding RemoveItemCommand}"
-                        CommandParameter="{Binding ElementName=Root, Path=SelectedItems}"
-                        Header="Remove Selected Items" />
+                    <MenuItem Command="{Binding RefreshPackageVersionCommand}" Header="Refresh Version" />
+                    <MenuItem Command="{Binding AddDirectoryCommand}" Header="Add Directory" />
+                    <MenuItem Command="{Binding RemoveItemCommand}" Header="Remove Selected Items" />
                     <MenuItem Command="{Binding RemoveAllItemsCommand}" Header="Remove All Items" />
                 </ContextMenu>
             </TreeView.ContextMenu>

--- a/src/Velopack.UI/Velopack.UI.csproj
+++ b/src/Velopack.UI/Velopack.UI.csproj
@@ -25,4 +25,8 @@
     <Resource Include="Images\**\*.*" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\MultiSelectTreeView\MultiSelectTreeView.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Velopack.UI/Views/MainView.xaml
+++ b/src/Velopack.UI/Views/MainView.xaml
@@ -26,7 +26,7 @@
         <xctk:BusyIndicator.BusyContentTemplate>
             <DataTemplate>
                 <!--  Ensure the Busy overlay binds to the window's DataContext (MainViewModel)  -->
-                <StackPanel
+                <ui:StackPanel
                     Width="250"
                     Margin="4"
                     DataContext="{Binding DataContext, RelativeSource={RelativeSource AncestorType={x:Type xctk:BusyIndicator}}}">
@@ -35,20 +35,20 @@
                         FontSize="18"
                         FontWeight="Bold"
                         Text="PACKAGE CREATION" />
-                    <StackPanel Margin="4" HorizontalAlignment="Stretch">
+                    <ui:StackPanel Margin="4" HorizontalAlignment="Stretch">
                         <ui:TextBlock FontSize="12" Text="{Binding CurrentPackageCreationStage}" />
                         <ProgressBar
                             Height="25"
                             Margin="5"
                             IsIndeterminate="True" />
-                    </StackPanel>
+                    </ui:StackPanel>
                     <ui:Button
                         Grid.Column="1"
                         Margin="2,0,0,0"
                         HorizontalAlignment="Center"
                         Command="{Binding AbortPackageCreationCmd}"
                         Content="Cancel" />
-                </StackPanel>
+                </ui:StackPanel>
             </DataTemplate>
         </xctk:BusyIndicator.BusyContentTemplate>
         <xctk:BusyIndicator.ProgressBarStyle>
@@ -57,48 +57,48 @@
             </Style>
         </xctk:BusyIndicator.ProgressBarStyle>
 
-        <Grid>
-            <Grid.Resources>
+        <ui:Grid>
+            <ui:Grid.Resources>
                 <Style x:Key="ListViewHideHeader" TargetType="{x:Type GridViewColumnHeader}">
                     <Setter Property="Visibility" Value="Collapsed" />
                 </Style>
 
-                <Style x:Key="Label" TargetType="{x:Type TextBlock}">
+                <Style x:Key="Label" TargetType="{x:Type ui:TextBlock}">
                     <Setter Property="FontSize" Value="14" />
                     <Setter Property="Foreground" Value="#555" />
                     <Setter Property="FontWeight" Value="Normal" />
                     <Setter Property="Margin" Value="4" />
                 </Style>
-            </Grid.Resources>
-            <Grid.RowDefinitions>
+            </ui:Grid.Resources>
+            <ui:Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-            <Grid
+            </ui:Grid.RowDefinitions>
+            <ui:Grid
                 x:Name="MainGrid"
                 Grid.Row="2"
                 DataContext="{Binding Model}">
-                <Grid.ColumnDefinitions>
+                <ui:Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" MinWidth="320" />
                     <ColumnDefinition Width="7" />
                     <ColumnDefinition Width="*" MinWidth="300" />
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
+                </ui:Grid.ColumnDefinitions>
+                <ui:Grid.RowDefinitions>
                     <RowDefinition Height="509*" />
                     <RowDefinition Height="204*" />
                     <RowDefinition Height="60" />
-                </Grid.RowDefinitions>
-                <GroupBox Grid.RowSpan="2" Margin="5,5,5,4.5">
-                    <GroupBox.Header>
+                </ui:Grid.RowDefinitions>
+                <ui:GroupBox Grid.RowSpan="2" Margin="5,5,5,4.5">
+                    <ui:GroupBox.Header>
                         <StackPanel Orientation="Horizontal">
                             <ui:TextBlock FontSize="14" Text="PACKAGE DETAILS" />
                         </StackPanel>
-                    </GroupBox.Header>
-                    <Grid>
-                        <Grid.RowDefinitions>
+                    </ui:GroupBox.Header>
+                    <ui:Grid>
+                        <ui:Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
 
                             <RowDefinition Height="Auto" />
@@ -153,7 +153,7 @@
 
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
+                        </ui:Grid.RowDefinitions>
                         <Menu
                             Grid.ColumnSpan="3"
                             Margin="0,0,0,12"
@@ -240,7 +240,7 @@
                             Grid.Column="0"
                             Style="{StaticResource ResourceKey=Label}"
                             Text="UPLOAD LOCATION" />
-                        <StackPanel
+                        <ui:StackPanel
                             Grid.Row="18"
                             Grid.Column="0"
                             Orientation="Horizontal">
@@ -258,65 +258,65 @@
                                 Command="{Binding EditCurrentConnectionCommand}"
                                 Content="Edit Connection"
                                 FontSize="16" />
-                        </StackPanel>
+                        </ui:StackPanel>
 
-                        <GroupBox Grid.Row="21" Header="Velopack Options">
-                            <Grid Margin="4">
-                                <Grid.ColumnDefinitions>
+                        <ui:GroupBox Grid.Row="21" Header="Velopack Options">
+                            <ui:Grid Margin="4">
+                                <ui:Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
+                                </ui:Grid.ColumnDefinitions>
+                                <ui:Grid.RowDefinitions>
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
+                                </ui:Grid.RowDefinitions>
                                 <CheckBox
                                     Grid.Row="0"
                                     Grid.Column="0"
                                     Margin="4"
                                     Content="Generate Delta Packages"
                                     IsChecked="{Binding GenerateDeltaPackages}" />
-                                <StackPanel
+                                <ui:StackPanel
                                     Grid.Row="1"
                                     Grid.Column="0"
                                     Margin="4"
                                     Orientation="Horizontal">
                                     <CheckBox Content="Generate MSI" IsChecked="{Binding GenerateMsi}" />
-                                    <TextBlock
+                                    <ui:TextBlock
                                         Margin="12,0,4,0"
                                         VerticalAlignment="Center"
                                         Text=" Bitness:" />
-                                    <ComboBox Width="80" SelectedItem="{Binding MsiBitness}">
+                                    <ui:ComboBox Width="80" SelectedItem="{Binding MsiBitness}">
                                         <sys:String>x86</sys:String>
                                         <sys:String>x64</sys:String>
-                                    </ComboBox>
-                                </StackPanel>
-                                <StackPanel
+                                    </ui:ComboBox>
+                                </ui:StackPanel>
+                                <ui:StackPanel
                                     Grid.Row="2"
                                     Grid.ColumnSpan="2"
                                     Margin="4"
                                     Orientation="Horizontal">
-                                    <TextBlock
+                                    <ui:TextBlock
                                         Width="100"
                                         VerticalAlignment="Center"
                                         Text="Sign Params:" />
-                                    <TextBox MinWidth="280" Text="{Binding SignParams}" />
-                                </StackPanel>
-                                <StackPanel
+                                    <ui:TextBox MinWidth="280" Text="{Binding SignParams}" />
+                                </ui:StackPanel>
+                                <ui:StackPanel
                                     Grid.Row="3"
                                     Grid.ColumnSpan="2"
                                     Margin="4"
                                     Orientation="Horizontal">
-                                    <TextBlock
+                                    <ui:TextBlock
                                         Width="100"
                                         VerticalAlignment="Center"
                                         Text="Sign Template:" />
-                                    <TextBox MinWidth="280" Text="{Binding SignTemplate}" />
-                                </StackPanel>
-                                <StackPanel
+                                    <ui:TextBox MinWidth="280" Text="{Binding SignTemplate}" />
+                                </ui:StackPanel>
+                                <ui:StackPanel
                                     Grid.Row="4"
                                     Grid.ColumnSpan="2"
                                     Margin="4"
@@ -326,16 +326,16 @@
                                         Command="{Binding AddFolderFromDialogCommand}"
                                         Content="Select Content Folder" />
                                     <ui:Button Command="{Binding AddFilesFromDialogCommand}" Content="Select Content Files" />
-                                </StackPanel>
-                            </Grid>
-                        </GroupBox>
+                                </ui:StackPanel>
+                            </ui:Grid>
+                        </ui:GroupBox>
 
-                        <Grid Grid.Row="23">
-                            <Grid.ColumnDefinitions>
+                        <ui:Grid Grid.Row="23">
+                            <ui:Grid.ColumnDefinitions>
                                 <ColumnDefinition />
                                 <ColumnDefinition />
-                            </Grid.ColumnDefinitions>
-                            <StackPanel
+                            </ui:Grid.ColumnDefinitions>
+                            <ui:StackPanel
                                 Grid.Column="0"
                                 Margin="4"
                                 Orientation="Vertical">
@@ -356,8 +356,8 @@
                                         Margin="3"
                                         Source="{Binding IconSource}" />
                                 </ui:Border>
-                            </StackPanel>
-                            <StackPanel
+                            </ui:StackPanel>
+                            <ui:StackPanel
                                 Grid.Column="1"
                                 Margin="4"
                                 Orientation="Vertical">
@@ -378,10 +378,10 @@
                                         Margin="3"
                                         Source="{Binding Path=SplashSource}" />
                                 </ui:Border>
-                            </StackPanel>
-                        </Grid>
+                            </ui:StackPanel>
+                        </ui:Grid>
 
-                        <StackPanel
+                        <ui:StackPanel
                             Grid.Row="25"
                             Margin="0,8,0,0"
                             HorizontalAlignment="Left"
@@ -391,8 +391,8 @@
                                 Command="{Binding SelectNupkgDirectoryCommand}"
                                 Content="Output: Content Folder" />
                             <ui:TextBlock VerticalAlignment="Center" Text="{Binding NupkgOutputPath}" />
-                        </StackPanel>
-                        <StackPanel
+                        </ui:StackPanel>
+                        <ui:StackPanel
                             Grid.Row="26"
                             HorizontalAlignment="Left"
                             Orientation="Horizontal">
@@ -401,9 +401,9 @@
                                 Command="{Binding SelectOutputDirectoryCommand}"
                                 Content="Output: Releases Folder" />
                             <ui:TextBlock VerticalAlignment="Center" Text="{Binding SquirrelOutputPath}" />
-                        </StackPanel>
-                    </Grid>
-                </GroupBox>
+                        </ui:StackPanel>
+                    </ui:Grid>
+                </ui:GroupBox>
                 <GridSplitter
                     Grid.RowSpan="2"
                     Grid.Column="1"
@@ -620,7 +620,7 @@
                         </ui:StackPanel>
                     </ui:Button>
                 </ui:Grid>
-            </Grid>
-        </Grid>
+            </ui:Grid>
+        </ui:Grid>
     </xctk:BusyIndicator>
 </UserControl>


### PR DESCRIPTION
Updated MultiSelectTreeViewControl to bind context menus directly to the view model via PlacementTarget.Tag, removing command parameters and improving multi-select handling. Also replaced standard WPF controls with custom 'ui:' controls in MainView.xaml for consistency, and added a project reference to MultiSelectTreeView. Minor code cleanups and improved comments throughout.