### PR TITLE
Improve MultiSelectTreeViewControl null safety and UI

### DIFF
--- a/src/Velopack.UI/Controls/MultiSelectTreeViewControl.xaml
+++ b/src/Velopack.UI/Controls/MultiSelectTreeViewControl.xaml
@@ -25,6 +25,7 @@
                     <Style TargetType="ui:Border">
                         <Setter Property="Background" Value="Transparent" />
                         <Setter Property="BorderBrush" Value="Transparent" />
+                        <Setter Property="TextElement.Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding IsSelected}" Value="True">
                                 <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
@@ -75,7 +76,7 @@
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
                 Data="M5.12,5L5.93,4H17.93L18.87,5M12,17.5L6.5,12H10V10H14V12H17.5L12,17.5M20.54,5.23L19.15,3.55C18.88,3.21 18.47,3 18,3H6C5.53,3 5.12,3.21 4.84,3.55L3.46,5.23C3.17,5.57 3,6 3,6.5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V6.5C21,6 20.83,5.57 20.54,5.23Z"
-                Fill="Blue"
+                Fill="{DynamicResource AccentFillColorDefaultBrush}"
                 Opacity=".25"
                 Stretch="Uniform" />
         </ui:Grid>
@@ -89,7 +90,7 @@
             AllowDrop="True"
             Background="{x:Null}"
             BorderThickness="0"
-            Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+            Foreground="{DynamicResource TextFillColorPrimaryBrush}"
             ItemTemplate="{Binding ElementName=Root, Path=ItemTemplate, TargetNullValue={StaticResource DefaultItemTemplate}}"
             ItemsSource="{Binding ElementName=Root, Path=ItemsSource}"
             PreviewKeyDown="OnTreeViewPreviewKeyDown"

--- a/src/Velopack.UI/Controls/MultiSelectTreeViewControl.xaml.cs
+++ b/src/Velopack.UI/Controls/MultiSelectTreeViewControl.xaml.cs
@@ -14,18 +14,23 @@ public partial class MultiSelectTreeViewControl : UserControl
     public MultiSelectTreeViewControl()
     {
         InitializeComponent();
-        SelectedItems = new ObservableCollection<object>();
+        // Do NOT set SelectedItems here; it breaks external TwoWay binding.
 
         // Ensure ContextMenus can find VM and SelectedItems via PlacementTarget.Tag
         Loaded += (_, _) =>
         {
-            PART_Tree.Tag = SelectedItems;
+            if (PART_Tree != null)
+            {
+                PART_Tree.Tag = SelectedItems;
+            }
         };
 
-        this.DataContextChanged += (_, __) =>
+        DataContextChanged += (_, __) =>
         {
-            // update TreeViewItem Tag is bound via ancestor UserControl, so no action here
-            PART_Tree.Tag = SelectedItems;
+            if (PART_Tree != null)
+            {
+                PART_Tree.Tag = SelectedItems;
+            }
         };
     }
 
@@ -44,9 +49,9 @@ public partial class MultiSelectTreeViewControl : UserControl
         set => SetValue(ItemsSourceProperty, value);
     }
 
-    public IList SelectedItems
+    public IList? SelectedItems
     {
-        get => (IList)GetValue(SelectedItemsProperty)!;
+        get => (IList?)GetValue(SelectedItemsProperty);
         set => SetValue(SelectedItemsProperty, value);
     }
 
@@ -85,6 +90,7 @@ public partial class MultiSelectTreeViewControl : UserControl
         if (IsOnExpander(e.OriginalSource as DependencyObject)) return;
         var container = FindContainer(e.OriginalSource as DependencyObject);
         if (container == null) return;
+        if (SelectedItems == null) return;
 
         var item = container.DataContext;
         if (!IsCtrlDown && !IsShiftDown)
@@ -117,6 +123,7 @@ public partial class MultiSelectTreeViewControl : UserControl
     {
         var container = FindContainer(e.OriginalSource as DependencyObject);
         if (container == null) return;
+        if (SelectedItems == null) return;
         var item = container.DataContext;
         if (!SelectedItems.Contains(item))
         {
@@ -131,6 +138,7 @@ public partial class MultiSelectTreeViewControl : UserControl
     {
         if (e.Key == Key.A && (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control)
         {
+            if (SelectedItems == null) return;
             ClearSelectionInternal();
             foreach (var tvi in Flatten(PART_Tree)) AddToSelection(tvi.DataContext);
             e.Handled = true;
@@ -139,6 +147,7 @@ public partial class MultiSelectTreeViewControl : UserControl
 
     private void ClearSelectionInternal()
     {
+        if (SelectedItems == null) return;
         foreach (var obj in SelectedItems.Cast<object>().ToList())
         {
             SetItemSelected(obj, false);
@@ -148,6 +157,7 @@ public partial class MultiSelectTreeViewControl : UserControl
 
     private void AddToSelection(object obj)
     {
+        if (SelectedItems == null) return;
         if (!SelectedItems.Contains(obj))
         {
             SelectedItems.Add(obj);
@@ -157,6 +167,7 @@ public partial class MultiSelectTreeViewControl : UserControl
 
     private void RemoveFromSelection(object obj)
     {
+        if (SelectedItems == null) return;
         if (SelectedItems.Contains(obj))
         {
             SelectedItems.Remove(obj);

--- a/src/Velopack.UI/MainWindow.xaml.cs
+++ b/src/Velopack.UI/MainWindow.xaml.cs
@@ -1,6 +1,9 @@
 ﻿using CrissCross;
 using CrissCross.WPF.UI.Appearance;
 using ReactiveUI;
+using System.ComponentModel;
+using System.Windows;
+using Splat;
 
 namespace Velopack.UI;
 
@@ -17,5 +20,50 @@ public partial class MainWindow
         {
             this.NavigateToView<MainViewModel>();
         });
+
+        Closing += OnClosing;
+    }
+
+    private void OnClosing(object? sender, CancelEventArgs e)
+    {
+        // Resolve MainViewModel from Splat service locator
+        var vm = Locator.Current.GetService<MainViewModel>();
+        if (vm != null && HasUnsavedChanges(vm))
+        {
+            var rslt = MessageBox.Show("Save changes before exit?", "Velopack UI", MessageBoxButton.YesNoCancel, MessageBoxImage.Question);
+            if (rslt == MessageBoxResult.Cancel)
+            {
+                e.Cancel = true;
+                return;
+            }
+            if (rslt == MessageBoxResult.Yes)
+            {
+                vm.Save();
+            }
+        }
+    }
+
+    private static bool HasUnsavedChanges(MainViewModel vm)
+    {
+        // If there is no model, nothing to save
+        if (vm.Model == null) return false;
+
+        // If project path not chosen yet, treat as dirty
+        if (string.IsNullOrWhiteSpace(vm.FilePath)) return true;
+
+        // Minimal heuristic: if the expected project file doesn't exist yet, it's dirty
+        try
+        {
+            var path = vm.FilePath!;
+            if (!path.EndsWith(PathFolderHelper.ProjectFileExtension))
+            {
+                path = System.IO.Path.Combine(path, $"{vm.Model.AppId}{PathFolderHelper.ProjectFileExtension}");
+            }
+            return !System.IO.File.Exists(path);
+        }
+        catch
+        {
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Added null checks for SelectedItems in MultiSelectTreeViewControl to prevent errors when binding externally. Updated XAML to use consistent dynamic resource brushes for foreground and accent colors. MainWindow now prompts to save unsaved changes on close, using a heuristic to detect dirty state.