### PR TITLE
Refactor output path handling and add Windows platform attributes

### DIFF
--- a/src/Velopack.UI/App.xaml.cs
+++ b/src/Velopack.UI/App.xaml.cs
@@ -1,9 +1,7 @@
 ﻿using System.Diagnostics;
-using System.IO;
 using System.Reactive.Concurrency;
 using System.Windows;
 using ReactiveUI;
-using Velopack;
 
 namespace Velopack.UI;
 

--- a/src/Velopack.UI/Classes/IconHelper.cs
+++ b/src/Velopack.UI/Classes/IconHelper.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
+﻿using System.Drawing;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -14,6 +13,7 @@ namespace Velopack.UI;
 /// Icon Helper
 /// </summary>
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1060:Move pinvokes to native methods class", Justification = "intended")]
+[SupportedOSPlatform("windows10.0.19041.0")]
 public static class IconHelper
 {
     /// <summary>
@@ -88,8 +88,13 @@ public static class IconHelper
     /// <param name="fileName">any filename</param>
     /// <param name="large">16x16 or 32x32 icon</param>
     /// <returns>null if path is null, otherwise - an icon</returns>
-    public static ImageSource? FindIconForFilename(string fileName, bool large)
+    public static ImageSource? FindIconForFilename(string? fileName, bool large)
     {
+        if (fileName == null)
+        {
+            return null;
+        }
+
         var extension = Path.GetExtension(fileName);
         if (extension == null)
         {
@@ -103,7 +108,7 @@ public static class IconHelper
         }
 
         icon = IconReader.GetFileIcon(fileName, large ? IconReader.IconSize.Large : IconReader.IconSize.Small, false).ToImageSource();
-        cache.Add(extension, icon);
+        cache.Add(extension, icon!);
         return icon;
     }
 
@@ -143,7 +148,7 @@ public static class IconHelper
 
         if (res == IntPtr.Zero)
         {
-            throw Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
+            throw Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error())!;
         }
 
         // Load the icon from an HICON handle
@@ -196,7 +201,7 @@ public static class IconHelper
     /// </summary>
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Not required")]
-    public struct SHFILEINFO
+    public record struct SHFILEINFO
     {
         /// <summary>
         /// The h icon
@@ -224,10 +229,6 @@ public static class IconHelper
         /// </summary>
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 80)]
         public string szTypeName;
-
-        public static bool operator ==(SHFILEINFO left, SHFILEINFO right) => left.Equals(right);
-
-        public static bool operator !=(SHFILEINFO left, SHFILEINFO right) => !(left == right);
     }
 
     /// <summary>

--- a/src/Velopack.UI/Classes/PathFolderHelper.cs
+++ b/src/Velopack.UI/Classes/PathFolderHelper.cs
@@ -22,21 +22,21 @@ public static class PathFolderHelper
     public const string ProjectFileExtension = ".velo";
 
     /// <summary>
-    /// The file dialog name
-    /// </summary>
-    public static string FileDialogName = ProgramName + " | *" + ProjectFileExtension;
-
-    /// <summary>
     /// The program base directory
     /// </summary>
-    public static string ProgramBaseDirectory = "\\" + ProgramName;
-    private static JsonSerializerOptions jsonOptions = new() { WriteIndented = true };
+    public const string ProgramBaseDirectory = "\\" + ProgramName;
+
+    /// <summary>
+    /// The file dialog name
+    /// </summary>
+    public const string FileDialogName = ProgramName + " | *" + ProjectFileExtension;
 
     // Use directory names without leading/trailing separators
-    internal const string PackageDirectory = "Packages";
+    internal const string PackageFilesDirectory = "PackageFiles";
     internal const string ReleasesDirectory = "Releases";
     private const string ProjectDirectory = "\\Projects\\";
-    private const string UserDataDirectory = "\\Data\\";
+
+    private static readonly JsonSerializerOptions jsonOptions = new() { WriteIndented = true };
 
     /// <summary>
     /// Gets the correct filepath.
@@ -71,10 +71,6 @@ public static class PathFolderHelper
 
         switch (directory)
         {
-            //case MyDirectory.PackageDir:
-            //    folderPath = GetMyDirectory(MyDirectory.Base) + PackageDirectory;
-            //    break;
-
             case MyDirectory.Project:
                 folderPath = GetMyDirectory(MyDirectory.Base) + ProjectDirectory;
                 break;
@@ -148,7 +144,6 @@ public static class PathFolderHelper
         try
         {
             var path = GetMyDirectory(MyDirectory.Base) + "\\Preference.txt";
-            // Serialize using System.Text.Json
             var jsonString = JsonSerializer.Serialize(userPreference, jsonOptions);
             File.WriteAllText(path, jsonString);
         }

--- a/src/Velopack.UI/Classes/SingleFileUpload.cs
+++ b/src/Velopack.UI/Classes/SingleFileUpload.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.IO;
 using System.Runtime.Serialization;
+using System.Runtime.Versioning;
 using System.Windows;
 using System.Windows.Threading;
 using Amazon.S3;
@@ -17,6 +17,7 @@ namespace Velopack.UI;
 /// Used in Upload queue list. I don't need serialization for this class.
 /// </summary>
 [DataContract]
+[SupportedOSPlatform("windows10.0.19041.0")]
 public class SingleFileUpload : RxObject
 {
     private string? _connection;

--- a/src/Velopack.UI/Controls/ItemInListConverter.cs
+++ b/src/Velopack.UI/Controls/ItemInListConverter.cs
@@ -1,7 +1,9 @@
 using System.Collections;
+using System.Runtime.Versioning;
 
 namespace Velopack.UI.MultiSelectTreeView.Controls;
 
+[SupportedOSPlatform("windows10.0.19041.0")]
 public class ItemInListConverter : System.Windows.Data.IMultiValueConverter
 {
     public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/src/Velopack.UI/Controls/ItemLink.cs
+++ b/src/Velopack.UI/Controls/ItemLink.cs
@@ -2,14 +2,16 @@
 using System.Drawing;
 using System.IO;
 using System.Runtime.Serialization;
+using System.Runtime.Versioning;
+using System.Text.Json.Serialization;
 using System.Windows.Media;
 using ReactiveUI;
 using ReactiveUI.SourceGenerators;
 using static Velopack.UI.IconHelper;
-using System.Text.Json.Serialization;
 
 namespace Velopack.UI;
 
+[SupportedOSPlatform("windows10.0.19041.0")]
 public partial class ItemLink : CrissCross.RxObject
 {
     private static readonly ItemLink s_dummyChild = new();
@@ -20,8 +22,8 @@ public partial class ItemLink : CrissCross.RxObject
     [DataMember]
     [Reactive]
     private bool _isSelected;
-    private string _sourceFilepath;
-    private string _filename;
+    private string? _sourceFilepath;
+    private string? _filename;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ItemLink"/> class.
@@ -172,20 +174,20 @@ public partial class ItemLink : CrissCross.RxObject
     /// </summary>
     /// <value>The last edit.</value>
     [DataMember]
-    public string LastEdit { get; internal set; }
+    public string? LastEdit { get; internal set; }
 
     /// <summary>
     /// Gets the output filename.
     /// </summary>
     /// <value>The output filename.</value>
     [DataMember]
-    public string OutputFilename { get; internal set; }
+    public string? OutputFilename { get; internal set; }
 
     /// <summary>
     /// Filepath of linked source file. Absolute ?
     /// </summary>
     [DataMember]
-    public string SourceFilepath
+    public string? SourceFilepath
     {
         get => _sourceFilepath;
 
@@ -193,6 +195,11 @@ public partial class ItemLink : CrissCross.RxObject
         {
             _sourceFilepath = value;
             this.RaisePropertyChanged(nameof(SourceFilepath));
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return;
+            }
+
             this.RaisePropertyChanged(nameof(Filename));
             try
             {

--- a/src/Velopack.UI/Controls/MultiSelectTreeViewControl.xaml.cs
+++ b/src/Velopack.UI/Controls/MultiSelectTreeViewControl.xaml.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Runtime.Versioning;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -7,6 +8,7 @@ using System.Windows.Media;
 
 namespace Velopack.UI.MultiSelectTreeView.Controls;
 
+[SupportedOSPlatform("windows10.0.19041.0")]
 public partial class MultiSelectTreeViewControl
 {
     public MultiSelectTreeViewControl()

--- a/src/Velopack.UI/MainWindow.xaml.cs
+++ b/src/Velopack.UI/MainWindow.xaml.cs
@@ -4,12 +4,14 @@ using ReactiveUI;
 using System.ComponentModel;
 using System.Windows;
 using Splat;
+using System.Runtime.Versioning;
 
 namespace Velopack.UI;
 
 /// <summary>
 /// Interaction logic for MainWindow.xaml
 /// </summary>
+[SupportedOSPlatform("windows10.0.19041.0")]
 public partial class MainWindow
 {
     public MainWindow()

--- a/src/Velopack.UI/Services/AmazonS3Connection.cs
+++ b/src/Velopack.UI/Services/AmazonS3Connection.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using System.Runtime.Versioning;
 using Amazon;
 using FluentValidation;
 using FluentValidation.Results;
@@ -12,6 +13,7 @@ namespace Velopack.UI;
 /// Credentials are stored in clear format.
 /// </summary>
 [DataContract]
+[SupportedOSPlatform("windows10.0.19041.0")]
 public partial class AmazonS3Connection : WebConnectionBase
 {
     [DataMember]

--- a/src/Velopack.UI/Services/CheckInternetConnection.cs
+++ b/src/Velopack.UI/Services/CheckInternetConnection.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace Velopack.UI;

--- a/src/Velopack.UI/Services/ConnectionDiscoveryService.cs
+++ b/src/Velopack.UI/Services/ConnectionDiscoveryService.cs
@@ -1,10 +1,12 @@
 using System.Reflection;
+using System.Runtime.Versioning;
 
 namespace Velopack.UI;
 
 /// <summary>
 /// The connection discovery service.
 /// </summary>
+[SupportedOSPlatform("windows10.0.19041.0")]
 public class ConnectionDiscoveryService : IConnectionDiscoveryService
 {
     private Dictionary<string, WebConnectionBase>? _availableConnections;

--- a/src/Velopack.UI/Services/FileSystemConnection.cs
+++ b/src/Velopack.UI/Services/FileSystemConnection.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using System.Runtime.Versioning;
 using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.Win32;
@@ -12,6 +13,7 @@ namespace Velopack.UI;
 /// Credentials are stored in clear format.
 /// </summary>
 [DataContract]
+[SupportedOSPlatform("windows10.0.19041.0")]
 public partial class FileSystemConnection : WebConnectionBase
 {
     private string? _fileSystemPath;

--- a/src/Velopack.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Velopack.UI/ViewModels/MainWindowViewModel.cs
@@ -1,10 +1,12 @@
-﻿using Velopack.UI.Views;
+﻿using System.Runtime.Versioning;
 using CrissCross;
 using ReactiveUI;
 using Splat;
+using Velopack.UI.Views;
 
 namespace Velopack.UI;
 
+[SupportedOSPlatform("windows10.0.19041.0")]
 public class MainWindowViewModel : RxObject
 {
     public MainWindowViewModel()

--- a/src/Velopack.UI/ViewModels/WebConnectionBase.cs
+++ b/src/Velopack.UI/ViewModels/WebConnectionBase.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Runtime.Serialization;
+using System.Runtime.Versioning;
 using System.Text;
 using CrissCross;
 using FluentValidation.Results;
-using ReactiveUI;
 using ReactiveUI.SourceGenerators;
 
 namespace Velopack.UI;
@@ -13,6 +12,7 @@ namespace Velopack.UI;
 /// Web Connection Base
 /// </summary>
 /// <seealso cref="AutoSquirrel.PropertyChangedBaseValidable"/>
+[SupportedOSPlatform("windows10.0.19041.0")]
 public abstract partial class WebConnectionBase : RxObject, IDataErrorInfo
 {
     [DataMember]

--- a/src/Velopack.UI/Views/MainView.xaml
+++ b/src/Velopack.UI/Views/MainView.xaml
@@ -260,7 +260,7 @@
                                 FontSize="16" />
                         </ui:StackPanel>
 
-                        <ui:GroupBox Grid.Row="21" Header="Velopack Options">
+                        <ui:GroupBox Grid.Row="23" Header="Velopack Options">
                             <ui:Grid Margin="4">
                                 <ui:Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
@@ -316,21 +316,10 @@
                                         Text="Sign Template:" />
                                     <ui:TextBox MinWidth="280" Text="{Binding SignTemplate}" />
                                 </ui:StackPanel>
-                                <ui:StackPanel
-                                    Grid.Row="4"
-                                    Grid.ColumnSpan="2"
-                                    Margin="4"
-                                    Orientation="Horizontal">
-                                    <ui:Button
-                                        Margin="0,0,8,0"
-                                        Command="{Binding AddFolderFromDialogCommand}"
-                                        Content="Select Content Folder" />
-                                    <ui:Button Command="{Binding AddFilesFromDialogCommand}" Content="Select Content Files" />
-                                </ui:StackPanel>
                             </ui:Grid>
                         </ui:GroupBox>
 
-                        <ui:Grid Grid.Row="23">
+                        <ui:Grid Grid.Row="21">
                             <ui:Grid.ColumnDefinitions>
                                 <ColumnDefinition />
                                 <ColumnDefinition />
@@ -390,7 +379,7 @@
                                 Margin="0,0,8,0"
                                 Command="{Binding SelectNupkgDirectoryCommand}"
                                 Content="Output: Content Folder" />
-                            <ui:TextBlock VerticalAlignment="Center" Text="{Binding NupkgOutputPath}" />
+                            <ui:TextBlock VerticalAlignment="Center" Text="{Binding PackageFilesOutputPath}" />
                         </ui:StackPanel>
                         <ui:StackPanel
                             Grid.Row="26"
@@ -400,7 +389,7 @@
                                 Margin="0,0,8,0"
                                 Command="{Binding SelectOutputDirectoryCommand}"
                                 Content="Output: Releases Folder" />
-                            <ui:TextBlock VerticalAlignment="Center" Text="{Binding SquirrelOutputPath}" />
+                            <ui:TextBlock VerticalAlignment="Center" Text="{Binding VelopackOutputPath}" />
                         </ui:StackPanel>
                     </ui:Grid>
                 </ui:GroupBox>
@@ -472,7 +461,7 @@
                                         Grid.Row="0"
                                         Grid.Column="2"
                                         Margin="4,0"
-                                        Text="{Binding DataContext.Model.SquirrelOutputPath, ElementName=mainView}"
+                                        Text="{Binding DataContext.Model.VelopackOutputPath, ElementName=mainView}"
                                         TextWrapping="Wrap" />
 
                                     <ui:TextBlock

--- a/src/Velopack.UI/WebConnectionEdit.xaml.cs
+++ b/src/Velopack.UI/WebConnectionEdit.xaml.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Windows;
 
 namespace Velopack.UI;


### PR DESCRIPTION
Standardizes output path properties in VelopackModel and MainViewModel, replacing NupkgOutputPath/SquirrelOutputPath with PackageFilesOutputPath/VelopackOutputPath. Adds [SupportedOSPlatform("windows10.0.19041.0")] attributes to relevant classes for platform targeting. Improves persistence and synchronization of FileSystem connection paths, updates UI bindings, and cleans up unused code and imports.