### PR TITLE
Add GitHub Releases upload support

### DIFF
--- a/src/Velopack.UI/App.xaml.cs
+++ b/src/Velopack.UI/App.xaml.cs
@@ -13,22 +13,18 @@ public partial class App
 {
     protected override void OnStartup(StartupEventArgs e)
     {
-        // Ensure Velopack bootstrap is invoked very early so vpk can validate it
-        try
-        {
-            VelopackApp.Build().Run();
-        }
-        catch
-        {
-            // non-fatal at runtime; packaging will still validate presence
-        }
-
-        //// Generate application icons (PNG + ICO) under Images
-        ////AppIconGenerator.EnsureAppIcons();
-
         base.OnStartup(e);
         TryPromptVelopackTool();
-        RxApp.TaskpoolScheduler.Schedule(async () => await UpdateMyApp("D:\\Installers\\Releases"));
+        RxApp.TaskpoolScheduler.Schedule(async () => await UpdateMyApp("https://github.com/ChrisPulman/Velopack.UI/releases"));
+    }
+
+    [STAThread]
+    private static void Main(string[] args)
+    {
+        VelopackApp.Build().Run();
+        App app = new();
+        app.InitializeComponent();
+        app.Run();
     }
 
     private static void TryPromptVelopackTool()

--- a/src/Velopack.UI/Controls/WebConnectionEdit.xaml
+++ b/src/Velopack.UI/Controls/WebConnectionEdit.xaml
@@ -10,7 +10,7 @@
     Width="640"
     Height="330"
     MinWidth="500"
-    MinHeight="330"
+    MinHeight="380"
     ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
     ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     ExtendsContentIntoTitleBar="True"
@@ -144,6 +144,93 @@
                         HorizontalAlignment="Left"
                         Command="{Binding SelectFolderCommand}"
                         Content="Select Folder" />
+                </ui:Grid>
+            </DataTemplate>
+            <!--  New GitHub Releases template  -->
+            <DataTemplate DataType="{x:Type local:GitHubReleasesConnection}">
+                <ui:Grid>
+                    <ui:Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition />
+                    </ui:Grid.ColumnDefinitions>
+                    <ui:Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </ui:Grid.RowDefinitions>
+                    <ui:TextBlock
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        Text="Owner:" />
+                    <ui:TextBox
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        Text="{Binding Owner, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
+
+                    <ui:TextBlock
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        Text="Repository:" />
+                    <ui:TextBox
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        Text="{Binding Repository, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
+
+                    <ui:TextBlock
+                        Grid.Row="2"
+                        Grid.Column="0"
+                        Text="Tag Name:" />
+                    <ui:TextBox
+                        Grid.Row="2"
+                        Grid.Column="1"
+                        Text="{Binding TagName, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
+
+                    <ui:TextBlock
+                        Grid.Row="3"
+                        Grid.Column="0"
+                        Text="Release Name:" />
+                    <ui:TextBox
+                        Grid.Row="3"
+                        Grid.Column="1"
+                        Text="{Binding ReleaseName, UpdateSourceTrigger=PropertyChanged}" />
+
+                    <ui:TextBlock
+                        Grid.Row="4"
+                        Grid.Column="0"
+                        Text="Token:" />
+                    <ui:TextBox
+                        Grid.Row="4"
+                        Grid.Column="1"
+                        Text="{Binding Token, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
+
+                    <CheckBox
+                        Grid.Row="5"
+                        Grid.Column="1"
+                        Content="Prerelease"
+                        IsChecked="{Binding Prerelease}" />
+                    <CheckBox
+                        Grid.Row="6"
+                        Grid.Column="1"
+                        Content="Draft"
+                        IsChecked="{Binding Draft}" />
+
+                    <ui:TextBlock
+                        Grid.Row="7"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        FontWeight="Bold"
+                        Text="Setup Link Url : " />
+                    <ui:TextBox
+                        Grid.Row="7"
+                        Grid.Column="1"
+                        FontWeight="Bold"
+                        IsReadOnly="True"
+                        Text="{Binding SetupDownloadUrl, Mode=OneWay}" />
                 </ui:Grid>
             </DataTemplate>
         </ui:Grid.Resources>

--- a/src/Velopack.UI/Services/GitHubReleasesConnection.cs
+++ b/src/Velopack.UI/Services/GitHubReleasesConnection.cs
@@ -1,0 +1,85 @@
+using System.Runtime.Serialization;
+using System.Runtime.Versioning;
+using FluentValidation;
+using FluentValidation.Results;
+using ReactiveUI;
+using ReactiveUI.SourceGenerators;
+
+namespace Velopack.UI;
+
+/// <summary>
+/// Publishes artifacts to GitHub Releases.
+/// Credentials are stored in plain text in the project file.
+/// </summary>
+[DataContract]
+[SupportedOSPlatform("windows10.0.19041.0")]
+public partial class GitHubReleasesConnection : WebConnectionBase
+{
+    [DataMember]
+    [Reactive]
+    private string? _owner;
+
+    [DataMember]
+    [Reactive]
+    private string? _repository;
+
+    [DataMember]
+    [Reactive]
+    private string? _tagName;
+
+    [DataMember]
+    [Reactive]
+    private string? _releaseName;
+
+    [DataMember]
+    [Reactive]
+    private bool _prerelease;
+
+    [DataMember]
+    [Reactive]
+    private bool _draft;
+
+    [DataMember]
+    [Reactive]
+    private string? _token; // GitHub PAT with repo scope
+
+    public GitHubReleasesConnection() => ConnectionName = "GitHub Releases";
+
+    /// <summary>
+    /// Example download URL for Setup.exe in this release.
+    /// </summary>
+    public string SetupDownloadUrl
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(Owner) || string.IsNullOrWhiteSpace(Repository) || string.IsNullOrWhiteSpace(TagName))
+            {
+                return "Missing Parameter";
+            }
+            return $"https://github.com/{Owner}/{Repository}/releases/download/{TagName}/***Setup.exe";
+        }
+    }
+
+    public override ValidationResult Validate()
+    {
+        this.RaisePropertyChanged(nameof(SetupDownloadUrl));
+        var commonValid = new Validator().Validate(this);
+        if (!commonValid.IsValid)
+        {
+            return commonValid;
+        }
+
+        return base.Validate();
+    }
+
+    private class Validator : AbstractValidator<GitHubReleasesConnection>
+    {
+        public Validator()
+        {
+            RuleFor(c => c.Owner).NotEmpty();
+            RuleFor(c => c.Repository).NotEmpty();
+            RuleFor(c => c.TagName).NotEmpty();
+            RuleFor(c => c.Token).NotEmpty();
+        }
+    }
+}

--- a/src/Velopack.UI/Services/GitHubReleasesConnection.cs
+++ b/src/Velopack.UI/Services/GitHubReleasesConnection.cs
@@ -56,7 +56,7 @@ public partial class GitHubReleasesConnection : WebConnectionBase
             {
                 return "Missing Parameter";
             }
-            return $"https://github.com/{Owner}/{Repository}/releases/download/{TagName}/***Setup.exe";
+            return $"https://github.com/{Owner}/{Repository}/releases/download/{TagName}/Setup.exe";
         }
     }
 

--- a/src/Velopack.UI/Services/SingleFileUpload.cs
+++ b/src/Velopack.UI/Services/SingleFileUpload.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Runtime.Versioning;
 using System.Windows;
@@ -12,11 +13,12 @@ using CrissCross;
 using ReactiveUI;
 using ReactiveUI.SourceGenerators;
 using Velopack.UI.Models;
+using Octokit;
 
 namespace Velopack.UI;
 
 /// <summary>
-/// Used in Upload queue list. I don't need serialization for this class.
+/// Used in Upload queue list.
 /// </summary>
 [DataContract]
 [SupportedOSPlatform("windows10.0.19041.0")]
@@ -51,6 +53,10 @@ public partial class SingleFileUpload : RxObject
             if (Connection is AmazonS3Connection s3 && !string.IsNullOrWhiteSpace(s3.BucketName) && !string.IsNullOrWhiteSpace(FullPath))
             {
                 return $"s3://{s3.BucketName}/{Path.GetFileName(FullPath)}";
+            }
+            if (Connection is GitHubReleasesConnection gh && !string.IsNullOrWhiteSpace(gh.Owner) && !string.IsNullOrWhiteSpace(gh.Repository) && !string.IsNullOrWhiteSpace(gh.TagName) && !string.IsNullOrWhiteSpace(FullPath))
+            {
+                return $"github://{gh.Owner}/{gh.Repository}/releases/{gh.TagName}/{Path.GetFileName(FullPath)}";
             }
             return null;
         }
@@ -157,6 +163,71 @@ public partial class SingleFileUpload : RxObject
             UploadStatus = FileUploadStatus.InProgress;
             uploadRequest_UploadPartProgressEvent(this, new UploadProgressArgs(100, 100, 100));
         }
+        else if (Connection is GitHubReleasesConnection ghCon)
+        {
+            if (!CheckInternetConnection.IsConnectedToInternet())
+            {
+                throw new Exception("Internet Connection not available");
+            }
+
+            if (string.IsNullOrWhiteSpace(ghCon.Token) || string.IsNullOrWhiteSpace(ghCon.Owner) || string.IsNullOrWhiteSpace(ghCon.Repository) || string.IsNullOrWhiteSpace(ghCon.TagName) || string.IsNullOrWhiteSpace(FullPath))
+            {
+                throw new Exception("Missing GitHub configuration");
+            }
+
+            UploadStatus = FileUploadStatus.InProgress;
+            ProgressPercentage = 5; // coarse update
+
+            var client = new GitHubClient(new ProductHeaderValue("Velopack.UI"))
+            {
+                Credentials = new Credentials(ghCon.Token)
+            };
+
+            // Find or create the release by tag
+            Release release;
+            try
+            {
+                release = await client.Repository.Release.Get(ghCon.Owner, ghCon.Repository, ghCon.TagName);
+            }
+            catch
+            {
+                var newRelease = new NewRelease(ghCon.TagName)
+                {
+                    Name = string.IsNullOrWhiteSpace(ghCon.ReleaseName) ? ghCon.TagName : ghCon.ReleaseName,
+                    Prerelease = ghCon.Prerelease,
+                    Draft = ghCon.Draft,
+                };
+                release = await client.Repository.Release.Create(ghCon.Owner, ghCon.Repository, newRelease);
+            }
+
+            ProgressPercentage = 25;
+
+            // Upload/replace asset
+            var fileName = Path.GetFileName(FullPath);
+
+            try
+            {
+                // If asset exists, delete to replace
+                var existing = release.Assets.FirstOrDefault(a => string.Equals(a.Name, fileName, StringComparison.OrdinalIgnoreCase));
+                if (existing != null)
+                {
+                    await client.Repository.Release.DeleteAsset(ghCon.Owner, ghCon.Repository, existing.Id);
+                }
+            }
+            catch { /* ignore */ }
+
+            await using var fs = File.OpenRead(FullPath);
+            var upload = new ReleaseAssetUpload
+            {
+                FileName = fileName,
+                ContentType = "application/octet-stream",
+                RawData = fs
+            };
+            _ = await client.Repository.Release.UploadAsset(release, upload);
+
+            ProgressPercentage = 100;
+            RequesteUploadComplete(new UploadCompleteEventArgs(this));
+        }
     }
 
     private static async Task CreateABucketAsync(AmazonS3Client client, string? bucketName)
@@ -185,13 +256,13 @@ public partial class SingleFileUpload : RxObject
 
         if (e.PercentDone == 100)
         {
-            if (Application.Current.Dispatcher.CheckAccess())
+            if (System.Windows.Application.Current.Dispatcher.CheckAccess())
             {
                 RequesteUploadComplete(new UploadCompleteEventArgs(this));
             }
             else
             {
-                Application.Current.Dispatcher.BeginInvoke(
+                System.Windows.Application.Current.Dispatcher.BeginInvoke(
                   DispatcherPriority.Background,
                   new Action(() => RequesteUploadComplete(new UploadCompleteEventArgs(this))));
             }

--- a/src/Velopack.UI/Velopack.UI.csproj
+++ b/src/Velopack.UI/Velopack.UI.csproj
@@ -12,6 +12,10 @@
     <ApplicationIcon>Images\Application.ico</ApplicationIcon>
     <Description>Velopack.UI by Chris Pulman — a Windows tool to build, sign, and publish Velopack (vpk) installers. Compose installer contents with drag &amp; drop, set metadata/icons, generate delta/full packages and optional MSI, then build and publish Releases.</Description>
     <StartupObject>Velopack.UI.App</StartupObject>
+    <Title>Velopack.UI</Title>
+    <Authors>Chris Pulman</Authors>
+    <PackageIcon>Application.png</PackageIcon>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,11 +35,18 @@
 
   <ItemGroup>
     <ApplicationDefinition Remove="App.xaml" />
-    <Page Include="App.xaml"/>
+    <Page Include="App.xaml" />
   </ItemGroup>
 
   <ItemGroup>
     <Content Include="Images\Application.ico" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Images\Application.png">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/Velopack.UI/Velopack.UI.csproj
+++ b/src/Velopack.UI/Velopack.UI.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="ReactiveUI.SourceGenerators" Version="2.4.1" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
     <PackageReference Include="AWSSDK.S3" Version="4.0.7.2" />

--- a/src/Velopack.UI/Velopack.UI.csproj
+++ b/src/Velopack.UI/Velopack.UI.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>Velopack.UI</RootNamespace>
     <ApplicationIcon>Images\Application.ico</ApplicationIcon>
     <Description>Velopack.UI by Chris Pulman — a Windows tool to build, sign, and publish Velopack (vpk) installers. Compose installer contents with drag &amp; drop, set metadata/icons, generate delta/full packages and optional MSI, then build and publish Releases.</Description>
+    <StartupObject>Velopack.UI.App</StartupObject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,6 +27,11 @@
 
   <ItemGroup>
     <Resource Include="Images\**\*.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ApplicationDefinition Remove="App.xaml" />
+    <Page Include="App.xaml"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Velopack.UI/ViewModels/MainViewModel.cs
+++ b/src/Velopack.UI/ViewModels/MainViewModel.cs
@@ -398,7 +398,7 @@ public partial class MainViewModel : RxObject
             return;
         }
 
-        // If FileSystem connection is selected with a path, prefer it for SquirrelOutputPath
+        // If FileSystem connection is selected with a path, prefer it for FileSystemBasePath
         string baseDir;
         if (Model.SelectedConnection is FileSystemConnection fsc && !string.IsNullOrWhiteSpace(fsc.FileSystemPath))
         {

--- a/src/Velopack.UI/Views/MainView.xaml
+++ b/src/Velopack.UI/Views/MainView.xaml
@@ -524,7 +524,7 @@
                                         DisplayMemberBinding="{Binding Path=Filename}"
                                         Header="Filename" />
                                     <GridViewColumn
-                                        Width="220"
+                                        Width="230"
                                         DisplayMemberBinding="{Binding Path=DestinationPath}"
                                         Header="Destination" />
                                     <GridViewColumn


### PR DESCRIPTION
Introduces a new GitHubReleasesConnection class for uploading artifacts to GitHub Releases, including UI for configuration and validation. Updates SingleFileUpload to support uploading files to GitHub Releases using Octokit, and adds the Octokit dependency. Minor UI adjustments and code comments were also updated for clarity.