### PR TITLE
Make startup checks async and add process helpers

### DIFF
--- a/src/Velopack.UI/App.xaml.cs
+++ b/src/Velopack.UI/App.xaml.cs
@@ -2,11 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
-using System.Reactive.Concurrency;
 using System.Security.Principal;
 using System.Windows;
+using System.Windows.Threading;
 using ReactiveUI;
 using ReactiveUI.Builder;
+using Velopack.Sources;
 
 namespace Velopack.UI;
 
@@ -21,6 +22,8 @@ public partial class App
     /// <param name="e">A <see cref="T:System.Windows.StartupEventArgs" /> that contains the event data.</param>
     protected override void OnStartup(StartupEventArgs e)
     {
+        RxAppBuilder.CreateReactiveUIBuilder().WithWpf().Build();
+
         base.OnStartup(e);
 
         // Check if running as administrator
@@ -35,10 +38,7 @@ public partial class App
             }
         }
 
-        TryPromptVelopackTool();
-        UpdateMyApp("https://github.com/ChrisPulman/Velopack.UI/releases").Wait();
-
-        RxAppBuilder.CreateReactiveUIBuilder().WithWpf().Build();
+        _ = Dispatcher.BeginInvoke(new Action(QueuePostStartupChecks), DispatcherPriority.ApplicationIdle);
     }
 
     [STAThread]
@@ -50,63 +50,87 @@ public partial class App
         app.Run();
     }
 
-    private static void TryPromptVelopackTool()
-    {
-        try
+    private static void QueueVelopackToolCheck() =>
+        _ = Task.Run(async () =>
         {
-            var psi = new ProcessStartInfo
+            try
             {
-                FileName = "dotnet",
-                Arguments = "tool list -g",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true
-            };
-            using var p = Process.Start(psi);
-            var outText = p!.StandardOutput.ReadToEnd();
-            p.WaitForExit();
-            if (!outText.Contains("vpk"))
-            {
-                var rslt = MessageBox.Show("The Velopack global tool 'vpk' is not installed. Install now?\nThis runs: dotnet tool install -g vpk", "Velopack Tool Missing", MessageBoxButton.YesNo, MessageBoxImage.Information);
-                if (rslt == MessageBoxResult.Yes)
-                {
-                    var install = new ProcessStartInfo
-                    {
-                        FileName = "dotnet",
-                        Arguments = "tool install -g vpk",
-                        UseShellExecute = false,
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true,
-                        CreateNoWindow = true
-                    };
-                    using var i = Process.Start(install);
-                    var stdout = i!.StandardOutput.ReadToEnd();
-                    var stderr = i!.StandardError.ReadToEnd();
-                    i.WaitForExit();
-                    if (i.ExitCode != 0)
-                    {
-                        MessageBox.Show($"Failed to install vpk:\n{stderr}\n{stdout}", "Install Error");
-                    }
-                }
+                await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+                await TryPromptVelopackToolAsync().ConfigureAwait(false);
             }
-        }
-        catch
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Velopack tool check failed: {ex}");
+            }
+        });
+
+    private static async Task TryPromptVelopackToolAsync()
+    {
+        var listResult = await RunProcessAsync("dotnet", TimeSpan.FromSeconds(30), "tool", "list", "-g").ConfigureAwait(false);
+        if (listResult.ExitCode != 0)
         {
-            // non-fatal
+            Trace.TraceWarning($"Failed to list global dotnet tools: {listResult.StandardError}{listResult.StandardOutput}");
+            return;
+        }
+
+        if (listResult.StandardOutput.Contains("vpk", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var rslt = await ShowMessageBoxAsync(
+            "The Velopack global tool 'vpk' is not installed. Install now?\nThis runs: dotnet tool install -g vpk",
+            "Velopack Tool Missing",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Information).ConfigureAwait(false);
+
+        if (rslt != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        var installResult = await RunProcessAsync("dotnet", TimeSpan.FromMinutes(2), "tool", "install", "-g", "vpk").ConfigureAwait(false);
+        if (installResult.ExitCode != 0)
+        {
+            await ShowMessageBoxAsync(
+                $"Failed to install vpk:\n{installResult.StandardError}\n{installResult.StandardOutput}",
+                "Install Error",
+                MessageBoxButton.OK,
+                MessageBoxImage.Error).ConfigureAwait(false);
         }
     }
 
-    private static async Task UpdateMyApp(string updatePath)
+    private static void QueuePostStartupChecks()
     {
-        var mgr = new UpdateManager(updatePath);
+        QueueVelopackToolCheck();
+        QueueUpdateCheck();
+    }
+
+    private static void QueueUpdateCheck() =>
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+                await UpdateMyApp().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Velopack update check failed: {ex}");
+            }
+        });
+
+    private static async Task UpdateMyApp()
+    {
+        var source = new GithubSource("https://github.com/ChrisPulman/Velopack.UI", accessToken: null, prerelease: false);
+        var mgr = new UpdateManager(source);
         if (!mgr.IsInstalled)
         {
             return; // not installed with Velopack, so skip update check
         }
 
         // check for new version
-        var newVersion = await mgr.CheckForUpdatesAsync();
+        var newVersion = await WithTimeout(mgr.CheckForUpdatesAsync(), TimeSpan.FromSeconds(30), "checking for updates").ConfigureAwait(false);
         if (newVersion == null)
         {
             return; // no update available
@@ -118,4 +142,94 @@ public partial class App
         // install new version and restart app
         mgr.ApplyUpdatesAndRestart(newVersion);
     }
+
+    private static async Task<T?> WithTimeout<T>(Task<T?> task, TimeSpan timeout, string operation)
+    {
+        var timeoutTask = Task.Delay(timeout);
+        var completedTask = await Task.WhenAny(task, timeoutTask).ConfigureAwait(false);
+        if (completedTask == timeoutTask)
+        {
+            Trace.TraceWarning($"Velopack timed out while {operation} after {timeout}.");
+            return default;
+        }
+
+        return await task.ConfigureAwait(false);
+    }
+
+    private static async Task<ProcessResult> RunProcessAsync(string fileName, TimeSpan timeout, params string[] arguments)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            }
+        };
+
+        foreach (var argument in arguments)
+        {
+            process.StartInfo.ArgumentList.Add(argument);
+        }
+
+        if (!process.Start())
+        {
+            return new ProcessResult(-1, string.Empty, $"Failed to start '{fileName}'.");
+        }
+
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+
+        try
+        {
+            using var timeoutToken = new CancellationTokenSource(timeout);
+            await process.WaitForExitAsync(timeoutToken.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            TryKill(process);
+            return new ProcessResult(-1, string.Empty, $"'{fileName}' timed out after {timeout}.");
+        }
+
+        return new ProcessResult(
+            process.ExitCode,
+            await standardOutput.ConfigureAwait(false),
+            await standardError.ConfigureAwait(false));
+    }
+
+    private static Task<MessageBoxResult> ShowMessageBoxAsync(string message, string title, MessageBoxButton buttons, MessageBoxImage image)
+    {
+        var dispatcher = Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.CheckAccess())
+        {
+            return Task.FromResult(ShowMessageBox(message, title, buttons, image));
+        }
+
+        return dispatcher.InvokeAsync(() => ShowMessageBox(message, title, buttons, image)).Task;
+    }
+
+    private static MessageBoxResult ShowMessageBox(string message, string title, MessageBoxButton buttons, MessageBoxImage image)
+    {
+        var owner = Current?.MainWindow;
+        return owner == null
+            ? MessageBox.Show(message, title, buttons, image)
+            : MessageBox.Show(owner, message, title, buttons, image);
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+            // Process may already have exited.
+        }
+    }
+
+    private readonly record struct ProcessResult(int ExitCode, string StandardOutput, string StandardError);
 }

--- a/src/Velopack.UI/Controls/VelopackUITreeViewControl.xaml
+++ b/src/Velopack.UI/Controls/VelopackUITreeViewControl.xaml
@@ -98,7 +98,6 @@
                     <Setter Property="Padding" Value="2" />
                     <Setter Property="Margin" Value="0" />
                     <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
-                    <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
                     <Setter Property="FontWeight" Value="Normal" />
                     <Setter Property="Tag" Value="{Binding DataContext, RelativeSource={RelativeSource AncestorType=UserControl}}" />
                     <Setter Property="ContextMenu">
@@ -112,9 +111,9 @@
                         </Setter.Value>
                     </Setter>
                     <Style.Triggers>
-                        <Trigger Property="IsSelected" Value="True">
+                        <DataTrigger Binding="{Binding IsSelected}" Value="True">
                             <Setter Property="FontWeight" Value="Bold" />
-                        </Trigger>
+                        </DataTrigger>
                     </Style.Triggers>
                 </Style>
             </TreeView.Resources>

--- a/src/Velopack.UI/Controls/VelopackUITreeViewControl.xaml.cs
+++ b/src/Velopack.UI/Controls/VelopackUITreeViewControl.xaml.cs
@@ -34,6 +34,12 @@ public partial class VelopackUITreeViewControl
         nameof(SelectedItems), typeof(IList), typeof(VelopackUITreeViewControl), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSelectedItemsChanged));
 
     /// <summary>
+    /// The selected item property.
+    /// </summary>
+    public static readonly DependencyProperty SelectedItemProperty = DependencyProperty.Register(
+        nameof(SelectedItem), typeof(object), typeof(VelopackUITreeViewControl), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+
+    /// <summary>
     /// The item template property.
     /// </summary>
     public static readonly DependencyProperty ItemTemplateProperty = DependencyProperty.Register(
@@ -78,6 +84,18 @@ public partial class VelopackUITreeViewControl
     }
 
     /// <summary>
+    /// Gets or sets the first selected item.
+    /// </summary>
+    /// <value>
+    /// The first selected item.
+    /// </value>
+    public object? SelectedItem
+    {
+        get => GetValue(SelectedItemProperty);
+        set => SetValue(SelectedItemProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the item template.
     /// </summary>
     /// <value>
@@ -97,6 +115,7 @@ public partial class VelopackUITreeViewControl
     {
         var ctl = (VelopackUITreeViewControl)d;
         ctl.PART_Tree?.Tag = ctl.SelectedItems;
+        ctl.UpdateSelectedItem();
     }
 
     private static bool IsOnExpander(DependencyObject? source)
@@ -208,7 +227,14 @@ public partial class VelopackUITreeViewControl
                 }
             }
         }
+        else if (IsShiftDown)
+        {
+            ClearSelectionInternal();
+            AddToSelection(item);
+            _lastAnchor = item;
+        }
 
+        Keyboard.Focus(container);
         e.Handled = true;
     }
 
@@ -237,6 +263,8 @@ public partial class VelopackUITreeViewControl
             _lastAnchor = item;
         }
 
+        Keyboard.Focus(container);
+
         // allow context menu
     }
 
@@ -255,6 +283,7 @@ public partial class VelopackUITreeViewControl
                 AddToSelection(tvi.DataContext);
             }
 
+            UpdateSelectedItem();
             e.Handled = true;
         }
     }
@@ -271,6 +300,8 @@ public partial class VelopackUITreeViewControl
             SetItemSelected(obj, false);
             SelectedItems.Remove(obj);
         }
+
+        UpdateSelectedItem();
     }
 
     private void AddToSelection(object obj)
@@ -284,6 +315,7 @@ public partial class VelopackUITreeViewControl
         {
             SelectedItems.Add(obj);
             SetItemSelected(obj, true);
+            UpdateSelectedItem();
         }
     }
 
@@ -298,6 +330,12 @@ public partial class VelopackUITreeViewControl
         {
             SelectedItems.Remove(obj);
             SetItemSelected(obj, false);
+            UpdateSelectedItem();
         }
+    }
+
+    private void UpdateSelectedItem()
+    {
+        SetCurrentValue(SelectedItemProperty, SelectedItems?.Cast<object>().FirstOrDefault());
     }
 }

--- a/src/Velopack.UI/Views/MainView.xaml
+++ b/src/Velopack.UI/Views/MainView.xaml
@@ -447,6 +447,7 @@
                             dd:DragDrop.UseDefaultDragAdorner="True"
                             AllowDrop="True"
                             ItemsSource="{Binding PackageFiles}"
+                            SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
                             SelectedItems="{Binding SelectedLink}" />
                         <ui:Border
                             Grid.Row="1"

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.6",
+    "version": "1.0.9",
     "publicReleaseRefSpec": [
         "^refs/heads/master$",
         "^refs/heads/main$"


### PR DESCRIPTION
Run ReactiveUI builder earlier and defer post-startup checks to the Dispatcher to avoid blocking UI. 
Add asynchronous checks for the Velopack global tool and app updates (using GithubSource), with RunProcessAsync, WithTimeout, ShowMessageBoxAsync, TryKill and a ProcessResult record to handle timeouts and errors robustly. Replace synchronous blocking/process calls with background tasks and trace warnings on failures. 
Also add TwoWay SelectedItem binding in MainView.xaml and bump version to 1.0.9.