### PR TITLE
Add GitHub CLI publisher and file association

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Velopack supports multiple publishing options. In Velopack.UI, set the Upload Lo
 - Generic web/FTP server: publish to a web directory that your app will use for updates.
 - Local/network folder: useful for testing / internal / self distribution.
 
+GitHub Releases uses GitHub CLI authentication by default. Install `gh`, run `gh auth login --web --hostname github.com --scopes repo`, then paste a repository URL such as `https://github.com/ChrisPulman/Velopack.UI` in the GitHub Releases connection editor. Velopack.UI uses `gh release create` for a new tag and `gh release upload --clobber` for an existing tag, so personal access tokens do not need to be stored in `.velo` files.
+
 For exact configuration strings and provider‑specific options, refer to the Velopack packaging docs: [Velopack Packaging](https://docs.velopack.io/category/packaging)
 
 

--- a/src/Velopack.UI/App.xaml.cs
+++ b/src/Velopack.UI/App.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows.Threading;
 using ReactiveUI;
 using ReactiveUI.Builder;
 using Velopack.Sources;
+using Velopack.UI.Helpers;
 
 namespace Velopack.UI;
 
@@ -16,6 +17,8 @@ namespace Velopack.UI;
 /// </summary>
 public partial class App
 {
+    internal static string? StartupProjectFilePath { get; private set; }
+
     /// <summary>
     /// Raises the <see cref="E:System.Windows.Application.Startup" /> event.
     /// </summary>
@@ -44,7 +47,16 @@ public partial class App
     [STAThread]
     private static void Main(string[] args)
     {
-        VelopackApp.Build().Run();
+        StartupProjectFilePath = FileAssociationHelper.GetProjectFileArgument(args);
+
+        VelopackApp.Build()
+            .SetArgs(args)
+            .OnAfterInstallFastCallback(_ => FileAssociationHelper.RegisterProjectFileAssociation())
+            .OnAfterUpdateFastCallback(_ => FileAssociationHelper.RegisterProjectFileAssociation())
+            .OnBeforeUninstallFastCallback(_ => FileAssociationHelper.UnregisterProjectFileAssociation())
+            .OnFirstRun(_ => FileAssociationHelper.RegisterProjectFileAssociation())
+            .Run();
+
         App app = new();
         app.InitializeComponent();
         app.Run();

--- a/src/Velopack.UI/Controls/WebConnectionEdit.xaml
+++ b/src/Velopack.UI/Controls/WebConnectionEdit.xaml
@@ -8,9 +8,9 @@
     xmlns:ui="https://github.com/reactivemarbles/CrissCross.ui"
     Title="{Binding Path=ConnectionName}"
     Width="640"
-    Height="330"
+    Height="470"
     MinWidth="500"
-    MinHeight="380"
+    MinHeight="470"
     ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
     ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     ExtendsContentIntoTitleBar="True"
@@ -163,6 +163,8 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </ui:Grid.RowDefinitions>
                     <ui:TextBlock
                         Grid.Row="0"
@@ -214,34 +216,61 @@
                         Grid.Row="5"
                         Grid.Column="0"
                         Width="150"
-                        Text="Personal access token (classic) - repo: "
+                        Text="Authentication:" />
+                    <ui:CheckBoxModern
+                        Grid.Row="5"
+                        Grid.Column="1"
+                        BoxSize="22"
+                        Checked="{Binding UseGitHubCliAuthentication}"
+                        Text="Use GitHub CLI browser sign-in" />
+
+                    <ui:TextBlock
+                        Grid.Row="6"
+                        Grid.Column="0"
+                        Width="150"
+                        Text="GitHub CLI:" />
+                    <ui:Button
+                        Grid.Row="6"
+                        Grid.Column="1"
+                        Width="220"
+                        Margin="0,4,0,4"
+                        HorizontalAlignment="Left"
+                        Click="GitHubCliSignIn_Click"
+                        Content="Sign in with GitHub CLI"
+                        ToolTip="Runs: gh auth login --web --hostname github.com --scopes repo" />
+
+                    <ui:TextBlock
+                        Grid.Row="7"
+                        Grid.Column="0"
+                        Width="150"
+                        Text="Fallback token:"
                         TextWrapping="Wrap" />
                     <ui:TextBox
-                        Grid.Row="5"
+                        Grid.Row="7"
                         Grid.Column="1"
                         Text="{Binding Token, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
 
                     <ui:CheckBoxModern
-                        Grid.Row="6"
+                        Grid.Row="8"
                         Grid.Column="1"
                         BoxSize="22"
                         Checked="{Binding Prerelease}"
                         Text="Prerelease" />
                     <ui:CheckBoxModern
-                        Grid.Row="7"
+                        Grid.Row="9"
                         Grid.Column="1"
                         BoxSize="22"
                         Checked="{Binding Draft}"
                         Text="Draft" />
 
                     <ui:TextBlock
-                        Grid.Row="8"
+                        Grid.Row="10"
                         Grid.Column="0"
                         VerticalAlignment="Center"
                         FontWeight="Bold"
                         Text="Setup Link Url : " />
                     <ui:TextBox
-                        Grid.Row="8"
+                        Grid.Row="10"
                         Grid.Column="1"
                         FontWeight="Bold"
                         IsReadOnly="True"
@@ -261,7 +290,7 @@
             VerticalAlignment="Center"
             FontSize="16"
             Foreground="Red"
-            Text="Credentials are stored in plain text! Do not add *.velo files to public source control" />
+            Text="GitHub CLI uses the system credential store. Fallback tokens are session-only and are not saved to *.velo files." />
         <ui:Button
             Grid.Row="2"
             Width="250"

--- a/src/Velopack.UI/Controls/WebConnectionEdit.xaml.cs
+++ b/src/Velopack.UI/Controls/WebConnectionEdit.xaml.cs
@@ -27,6 +27,18 @@ public partial class WebConnectionEdit
         Close();
     }
 
+    private void GitHubCliSignIn_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            GitHubCliReleasePublisher.StartInteractiveSignIn();
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, $"Unable to start GitHub CLI sign-in: {ex.Message}", "GitHub CLI", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
     private void Hyperlink_Click(object sender, RoutedEventArgs e) =>
         Process.Start("http://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html");
 }

--- a/src/Velopack.UI/Helpers/FileAssociationHelper.cs
+++ b/src/Velopack.UI/Helpers/FileAssociationHelper.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Microsoft.Win32;
+
+namespace Velopack.UI.Helpers;
+
+/// <summary>
+/// Registers Velopack.UI project files with Windows for the current user.
+/// </summary>
+[SupportedOSPlatform("windows10.0.19041.0")]
+internal static class FileAssociationHelper
+{
+    private const string ProgId = "Velopack.UI.Project";
+    private const string Extension = PathFolderHelper.ProjectFileExtension;
+
+    internal static string? GetProjectFileArgument(IEnumerable<string>? args)
+    {
+        if (args == null)
+        {
+            return null;
+        }
+
+        foreach (var arg in args)
+        {
+            var path = arg.Trim().Trim('"');
+            if (string.Equals(Path.GetExtension(path), Extension, StringComparison.OrdinalIgnoreCase) && File.Exists(path))
+            {
+                return Path.GetFullPath(path);
+            }
+        }
+
+        return null;
+    }
+
+    internal static void RegisterProjectFileAssociation()
+    {
+        var executablePath = Environment.ProcessPath;
+        if (string.IsNullOrWhiteSpace(executablePath) || !File.Exists(executablePath))
+        {
+            executablePath = Process.GetCurrentProcess().MainModule?.FileName;
+        }
+
+        if (string.IsNullOrWhiteSpace(executablePath) || !File.Exists(executablePath))
+        {
+            return;
+        }
+
+        using (var extensionKey = Registry.CurrentUser.CreateSubKey($@"Software\Classes\{Extension}"))
+        {
+            extensionKey?.SetValue(null, ProgId);
+            extensionKey?.SetValue("Content Type", "application/json");
+            extensionKey?.SetValue("PerceivedType", "text");
+        }
+
+        using (var progIdKey = Registry.CurrentUser.CreateSubKey($@"Software\Classes\{ProgId}"))
+        {
+            progIdKey?.SetValue(null, "Velopack.UI Project");
+            progIdKey?.SetValue("FriendlyTypeName", "Velopack.UI Project");
+        }
+
+        using (var defaultIconKey = Registry.CurrentUser.CreateSubKey($@"Software\Classes\{ProgId}\DefaultIcon"))
+        {
+            defaultIconKey?.SetValue(null, Quote(executablePath) + ",0");
+        }
+
+        using (var commandKey = Registry.CurrentUser.CreateSubKey($@"Software\Classes\{ProgId}\shell\open\command"))
+        {
+            commandKey?.SetValue(null, $"{Quote(executablePath)} \"%1\"");
+        }
+
+        NotifyShellAssociationChanged();
+    }
+
+    internal static void UnregisterProjectFileAssociation()
+    {
+        using (var extensionKey = Registry.CurrentUser.OpenSubKey($@"Software\Classes\{Extension}", writable: true))
+        {
+            if (extensionKey != null &&
+                string.Equals(extensionKey.GetValue(null) as string, ProgId, StringComparison.OrdinalIgnoreCase))
+            {
+                extensionKey.DeleteValue(string.Empty, throwOnMissingValue: false);
+            }
+        }
+
+        Registry.CurrentUser.DeleteSubKeyTree($@"Software\Classes\{ProgId}", throwOnMissingSubKey: false);
+        NotifyShellAssociationChanged();
+    }
+
+    private static string Quote(string value) => "\"" + value + "\"";
+
+    private static void NotifyShellAssociationChanged()
+    {
+        try
+        {
+            NativeMethods.SHChangeNotify(0x08000000, 0, IntPtr.Zero, IntPtr.Zero);
+        }
+        catch
+        {
+            // The association is registered even if the shell notification fails.
+        }
+    }
+
+    private static partial class NativeMethods
+    {
+        [DllImport("shell32.dll")]
+        internal static extern void SHChangeNotify(uint wEventId, uint uFlags, IntPtr dwItem1, IntPtr dwItem2);
+    }
+}

--- a/src/Velopack.UI/Services/GitHubCliReleasePublisher.cs
+++ b/src/Velopack.UI/Services/GitHubCliReleasePublisher.cs
@@ -1,0 +1,221 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.Versioning;
+using System.Text;
+
+namespace Velopack.UI;
+
+/// <summary>
+/// Publishes release assets by delegating authentication and release operations to GitHub CLI.
+/// </summary>
+[SupportedOSPlatform("windows10.0.19041.0")]
+internal static class GitHubCliReleasePublisher
+{
+    internal static async Task PublishAsync(GitHubReleasesConnection connection, IReadOnlyCollection<string> files, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+
+        if (files.Count == 0)
+        {
+            throw new InvalidOperationException("No release files were found to upload.");
+        }
+
+        var owner = Require(connection.Owner, "GitHub owner is required.");
+        var repository = Require(connection.Repository, "GitHub repository is required.");
+        var tagName = Require(connection.TagName, "GitHub release tag is required.");
+        var repositorySelector = $"{owner}/{repository}";
+
+        await EnsureGitHubCliReadyAsync(cancellationToken).ConfigureAwait(false);
+
+        var releaseExists = await ReleaseExistsAsync(repositorySelector, tagName, cancellationToken).ConfigureAwait(false);
+        if (releaseExists)
+        {
+            await UploadAssetsAsync(repositorySelector, tagName, files, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        await CreateReleaseAsync(repositorySelector, connection, files, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static void StartInteractiveSignIn()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "cmd.exe",
+            Arguments = "/k gh auth login --web --hostname github.com --scopes repo",
+            UseShellExecute = true,
+            WindowStyle = ProcessWindowStyle.Normal
+        };
+
+        Process.Start(startInfo);
+    }
+
+    private static async Task EnsureGitHubCliReadyAsync(CancellationToken cancellationToken)
+    {
+        var version = await RunGhAsync(["--version"], TimeSpan.FromSeconds(15), cancellationToken).ConfigureAwait(false);
+        if (version.ExitCode != 0)
+        {
+            throw new InvalidOperationException("GitHub CLI was not found. Install GitHub CLI, then sign in with: gh auth login --web --hostname github.com --scopes repo");
+        }
+
+        var authStatus = await RunGhAsync(["auth", "status", "--hostname", "github.com"], TimeSpan.FromSeconds(30), cancellationToken).ConfigureAwait(false);
+        if (authStatus.ExitCode != 0)
+        {
+            throw new InvalidOperationException("GitHub CLI is not authenticated for github.com. Click 'Sign in with GitHub CLI' or run: gh auth login --web --hostname github.com --scopes repo");
+        }
+    }
+
+    private static async Task<bool> ReleaseExistsAsync(string repositorySelector, string tagName, CancellationToken cancellationToken)
+    {
+        var result = await RunGhAsync(
+            ["release", "view", tagName, "--repo", repositorySelector],
+            TimeSpan.FromSeconds(30),
+            cancellationToken).ConfigureAwait(false);
+
+        if (result.ExitCode == 0)
+        {
+            return true;
+        }
+
+        var output = result.CombinedOutput;
+        if (output.Contains("not found", StringComparison.OrdinalIgnoreCase) ||
+            output.Contains("could not resolve", StringComparison.OrdinalIgnoreCase) ||
+            output.Contains("HTTP 404", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        throw new InvalidOperationException("Unable to inspect GitHub release: " + output);
+    }
+
+    private static Task CreateReleaseAsync(string repositorySelector, GitHubReleasesConnection connection, IReadOnlyCollection<string> files, CancellationToken cancellationToken)
+    {
+        var tagName = Require(connection.TagName, "GitHub release tag is required.");
+        var releaseName = string.IsNullOrWhiteSpace(connection.ReleaseName) ? tagName : connection.ReleaseName.Trim();
+        var args = new List<string>
+        {
+            "release",
+            "create",
+            tagName,
+        };
+
+        args.AddRange(files.Select(Path.GetFullPath));
+        args.AddRange(["--repo", repositorySelector, "--title", releaseName, "--notes", $"Velopack release {tagName}."]);
+
+        if (connection.Draft)
+        {
+            args.Add("--draft");
+        }
+
+        if (connection.Prerelease)
+        {
+            args.Add("--prerelease");
+        }
+
+        return RunGhCheckedAsync(args, TimeSpan.FromMinutes(30), "GitHub release creation failed", cancellationToken);
+    }
+
+    private static Task UploadAssetsAsync(string repositorySelector, string tagName, IReadOnlyCollection<string> files, CancellationToken cancellationToken)
+    {
+        var args = new List<string>
+        {
+            "release",
+            "upload",
+            tagName,
+        };
+
+        args.AddRange(files.Select(Path.GetFullPath));
+        args.AddRange(["--repo", repositorySelector, "--clobber"]);
+
+        return RunGhCheckedAsync(args, TimeSpan.FromMinutes(30), "GitHub release upload failed", cancellationToken);
+    }
+
+    private static async Task RunGhCheckedAsync(IReadOnlyCollection<string> args, TimeSpan timeout, string failurePrefix, CancellationToken cancellationToken)
+    {
+        var result = await RunGhAsync(args, timeout, cancellationToken).ConfigureAwait(false);
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"{failurePrefix}: {result.CombinedOutput}");
+        }
+    }
+
+    private static async Task<ProcessResult> RunGhAsync(IReadOnlyCollection<string> args, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "gh",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8
+            }
+        };
+
+        foreach (var arg in args)
+        {
+            process.StartInfo.ArgumentList.Add(arg);
+        }
+
+        try
+        {
+            if (!process.Start())
+            {
+                return new ProcessResult(-1, string.Empty, "Failed to start GitHub CLI.");
+            }
+        }
+        catch (Win32Exception ex)
+        {
+            return new ProcessResult(-1, string.Empty, $"Failed to start GitHub CLI: {ex.Message}");
+        }
+
+        var standardOutput = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var standardError = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        try
+        {
+            using var timeoutToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutToken.CancelAfter(timeout);
+            await process.WaitForExitAsync(timeoutToken.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            TryKill(process);
+            return new ProcessResult(-1, string.Empty, $"GitHub CLI timed out after {timeout}.");
+        }
+
+        return new ProcessResult(
+            process.ExitCode,
+            await standardOutput.ConfigureAwait(false),
+            await standardError.ConfigureAwait(false));
+    }
+
+    private static string Require(string? value, string message) =>
+        string.IsNullOrWhiteSpace(value) ? throw new InvalidOperationException(message) : value.Trim();
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+            // Process may already have exited.
+        }
+    }
+
+    private readonly record struct ProcessResult(int ExitCode, string StandardOutput, string StandardError)
+    {
+        public string CombinedOutput => string.Join(
+            Environment.NewLine,
+            new[] { StandardError, StandardOutput }.Where(output => !string.IsNullOrWhiteSpace(output))).Trim();
+    }
+}

--- a/src/Velopack.UI/Services/GitHubReleasesConnection.cs
+++ b/src/Velopack.UI/Services/GitHubReleasesConnection.cs
@@ -48,9 +48,13 @@ public partial class GitHubReleasesConnection : WebConnectionBase
     [Reactive]
     private bool _draft;
 
+    [DataMember]
+    [Reactive]
+    private bool _useGitHubCliAuthentication = true;
+
     [Reactive]
     [JsonIgnore]
-    private string? _token; // GitHub PAT with repo scope
+    private string? _token; // Optional fallback token used only for the current session.
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GitHubReleasesConnection"/> class.
@@ -183,7 +187,7 @@ public partial class GitHubReleasesConnection : WebConnectionBase
             RuleFor(c => c.Owner).NotEmpty();
             RuleFor(c => c.Repository).NotEmpty();
             RuleFor(c => c.TagName).NotEmpty();
-            RuleFor(c => c.Token).NotEmpty();
+            RuleFor(c => c.Token).NotEmpty().When(c => !c.UseGitHubCliAuthentication);
         }
     }
 }

--- a/src/Velopack.UI/Services/SingleFileUpload.cs
+++ b/src/Velopack.UI/Services/SingleFileUpload.cs
@@ -142,7 +142,7 @@ public partial class SingleFileUpload : RxObject
         }
     }
 
-    internal async void StartUpload()
+    internal async Task StartUploadAsync()
     {
         if (Connection is AmazonS3Connection amazonCon)
         {

--- a/src/Velopack.UI/ViewModels/MainViewModel.cs
+++ b/src/Velopack.UI/ViewModels/MainViewModel.cs
@@ -115,7 +115,10 @@ public partial class MainViewModel : RxObject
 
         UserPreference = PathFolderHelper.LoadUserPreference();
 
-        var last = UserPreference.LastOpenedProject.LastOrDefault();
+        var startupProject = App.StartupProjectFilePath;
+        var last = string.IsNullOrWhiteSpace(startupProject)
+            ? UserPreference.LastOpenedProject.LastOrDefault()
+            : startupProject;
 
         if (!string.IsNullOrEmpty(last) && File.Exists(last))
         {

--- a/src/Velopack.UI/ViewModels/VelopackModel.cs
+++ b/src/Velopack.UI/ViewModels/VelopackModel.cs
@@ -627,6 +627,12 @@ public partial class VelopackModel : WebConnectionBase, IDropTarget
             }
         }
 
+        if (SelectedConnection is GitHubReleasesConnection { UseGitHubCliAuthentication: true } githubConnection)
+        {
+            _ = PublishGitHubReleaseWithCliAsync(githubConnection, updatedFiles.ConvertAll(file => file.FullName));
+            return;
+        }
+
         ProcessNextUploadFile();
     }
 
@@ -1516,53 +1522,65 @@ public partial class VelopackModel : WebConnectionBase, IDropTarget
         }
     }
 
-    private void ProcessNextUploadFile()
+    private async Task PublishGitHubReleaseWithCliAsync(GitHubReleasesConnection connection, IReadOnlyCollection<string> files)
+    {
+        try
+        {
+            foreach (var item in UploadQueue.Where(item => item.UploadStatus == FileUploadStatus.Queued))
+            {
+                item.UploadStatus = FileUploadStatus.InProgress;
+                item.ProgressPercentage = 5;
+            }
+
+            await GitHubCliReleasePublisher.PublishAsync(connection, files).ConfigureAwait(true);
+
+            foreach (var item in UploadQueue)
+            {
+                item.UploadStatus = FileUploadStatus.Completed;
+                item.ProgressPercentage = 100;
+            }
+        }
+        catch (Exception ex)
+        {
+            foreach (var item in UploadQueue.Where(item => item.UploadStatus != FileUploadStatus.Completed))
+            {
+                item.UploadStatus = FileUploadStatus.Failed;
+            }
+
+            MessageBox.Show(ex.Message, "GitHub Release Publish Failed", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    private async void ProcessNextUploadFile()
     {
         if (UploadQueue == null || UploadQueue.Count == 0)
         {
             return;
         }
 
-        // Find next queued item
-        var item = UploadQueue.FirstOrDefault(f => f.UploadStatus == FileUploadStatus.Queued);
-        if (item == null)
+        foreach (var item in UploadQueue.Where(f => f.UploadStatus == FileUploadStatus.Queued).ToList())
         {
-            return; // nothing left to do
-        }
-
-        item.UploadStatus = FileUploadStatus.InProgress;
-        try
-        {
-            // For FileSystem connection, ensure the file exists at the destination
-            if (item.Connection is FileSystemConnection fsConn && !string.IsNullOrWhiteSpace(fsConn.FileSystemPath))
+            item.UploadStatus = FileUploadStatus.InProgress;
+            try
             {
-                item.ProgressPercentage = 100;
-                item.UploadStatus = FileUploadStatus.Completed;
-            }
-            else
-            {
-                // Fallback: try to use the built-in upload implementation if available
-                try
+                // For FileSystem connection, ensure the file exists at the destination
+                if (item.Connection is FileSystemConnection fsConn && !string.IsNullOrWhiteSpace(fsConn.FileSystemPath))
                 {
-                    item.StartUpload();
-                }
-                catch
-                {
-                    // If upload provider not implemented, mark as completed to keep UI flowing
                     item.ProgressPercentage = 100;
                     item.UploadStatus = FileUploadStatus.Completed;
                 }
+                else
+                {
+                    await item.StartUploadAsync().ConfigureAwait(true);
+                }
+            }
+            catch (Exception ex)
+            {
+                item.ProgressPercentage = 100;
+                item.UploadStatus = FileUploadStatus.Failed;
+                MessageBox.Show(ex.Message, "Upload Failed", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
-        catch
-        {
-            // Mark as completed even on failure for now; extend with error handling as needed
-            item.ProgressPercentage = 100;
-            item.UploadStatus = FileUploadStatus.Completed;
-        }
-
-        // Continue with any remaining items
-        ProcessNextUploadFile();
     }
 
     // -------- Disk sync helpers for PackageFiles mirror --------


### PR DESCRIPTION
Add GitHub CLI-based release publishing and Windows file association handling, plus related UI and upload flow changes.

Changes:
- Add GitHubCliReleasePublisher: runs `gh` to create/upload releases and supports interactive sign-in.
- Add FileAssociationHelper: register/unregister .velo project file association and extract startup file argument.
- Integrate file association and startup project handling in App.Main (register/unregister on install/update/first run and expose StartupProjectFilePath).
- Update README to document GitHub CLI auth usage and recommended sign-in command.
- WebConnectionEdit UI: larger dialog, add GitHub CLI sign-in button and CLI auth checkbox; update explanatory text; wire up click handler to start CLI sign-in.
- GitHubReleasesConnection: add UseGitHubCliAuthentication flag, make token a session-only fallback, and validate token only when CLI auth is not used.
- SingleFileUpload: rename StartUpload -> StartUploadAsync and make it async.
- MainViewModel: honor startup project file argument when opening last project.
- VelopackModel: add path for publishing via GitHub CLI (PublishGitHubReleaseWithCliAsync) and refactor upload processing to use async uploads, update upload statuses and error handling.

Rationale: allow using GitHub CLI for authentication so personal access tokens need not be persisted in .velo files; improve UX for project file associations and robust async upload/release flows.